### PR TITLE
Add section with guidelines for Slot Aggregators

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,15 @@ We are parsimonious in our use of standards, so that:
 
 ## Roles and responsibilities
 
-This specification defines three functional roles:
+This specification defines four functional roles:
 
 * **Slot Discovery Client**: the booking tool of a patient's choice. This system discovers appointment slots on a patient's behalf, and helps the patient choose the best slots to book (e.g., by evaluating trade-offs of travel distance or wait time).
 
 * **Slot Publisher**: the API service offered by a healthcare provider, advertising available slots. Critically, advertising a slot should be low-risk, since the mere fact that a slot is advertised does *not* guarantee that any given patient will be allowed to book the slot; instead, sophisticated rules can be implemented by the...
 
 * **Provider Booking Portal**: the UI service offered by a healthcare provider, enabling a user to book a selected slot. This is the place where provider-specific rules can be implemented, e.g. to ensure that patients booking a specialty appointment are appropriate candidates for that specialist's care. (In many implementations, this UI will be housed within a general-purpose provider-hosted patient portal.)
+
+*  **Slot Aggregator**: an API service offered by public health authorities or other third parties, aggregating data from multiple _Slot Publishers_ or from other healthcare provider APIs. _Slot Aggregators_ otherwise act in a similar capacity to _Slot Publishers_.
 
 ## Is the UX good enough?
 

--- a/specification.md
+++ b/specification.md
@@ -214,13 +214,6 @@ Each Schedule object may optionally include the following extension JSON objects
 	|`url`| string | fixed value of `"http://fhir-registry.smarthealthit.org/StructureDefinition/vaccine-dose"`|
 	|`valueInteger` | number | indicates sequence number (should be be `1` or `2` for current vaccines)|
 
-* "Has Availability" extension: optional field to convey that a Schedule has non-zero future availability, without conveying details about when or how much. Slot Publishers SHALL NOT use this capacity in place of publishing granular Slots; it is defined to support Slot Aggregators (i.e. systems that re-publish Slot data from other APIs).
-
-	| field name | type  | description |
-	|---|---|---|
-	|`url`| string | fixed value of `"http://fhir-registry.smarthealthit.org/StructureDefinition/has-availability"`|
-	|`valueBoolean` | boolean | `true` if this Schedule has non-zero future availability; `false` otherwise|
-
 ### Example `Schedule`
 
 ```json
@@ -344,3 +337,183 @@ In this case, if the `source` value is `source-abc` and the `booking-referral` i
     https://ehr-portal.example.org/bookings?slot=opaque-slot-handle-89172489&source=source-abc&booking-referral=34d1a803-cd6c-4420-9cf5-c5edcc533538
 
 (Note: this construction is *not* as simple as just appending `&source=...` to the booking-deep-link, because the booking-deep-link may or may not already include URL parameters. The Slot Discovery Client must take care to parse the booking-deep-link and append parameters, e.g., including a `?` prefix if not already present.)
+
+
+## Slot Aggregators
+
+Systems that re-publish data from multiple other APIs or from other _Slot Publishers_ are referred to as _Slot Aggregators_. If you are a _Slot Aggregator_, you may wish to use some additional extensions and FHIR features to supply useful provenance information or describe ways that your aggregated data may not exactly match the definitions in the _SMART Scheduling Links_ specification. The practices and approaches in this section are _recommendations_; none are _required_ for a valid implementation.
+
+
+### Preserve Source Identifiers
+
+_Slot Aggregators_ usually need to assign new `id` values to resources in order to make sure they are unique across the aggregated dataset. The `id` of the original resource SHOULD be preserved in the `identifier` list, alongside the identifiers from the original resource. The specific `system` and `value` used for the identifier is left up to the implementer.
+
+For example, given this Location resource from an underlying source:
+
+```js
+{
+  "resourceType": "Location",
+  "id": "123",
+  "identifier": [
+    {
+      "system": "https://cdc.gov/vaccines/programs/vtrcks",
+      "value": "CV1654321"
+    }
+  ],
+  "name": "Flynn's Pharmacy in Pittsfield, MA",
+  // additional Location fields here...
+}
+```
+
+A _Slot Aggregator_ might publish a Location like:
+
+```js
+{
+  "resourceType": "Location",
+  "id": "456",
+  "identifier": [
+    {
+      "system": "https://cdc.gov/vaccines/programs/vtrcks",
+      "value": "CV1654321"
+    },
+    {
+      "system": "https://flynnspharmacy.org/",
+      "value": "123"
+    }
+  ],
+  "name": "Flynn's Pharmacy in Pittsfield, MA",
+  // additional Location fields here...
+}
+```
+
+In this example, `https://flynnspharmacy.org/` is an arbitrary string that defines “Flynn’s Pharmacy” as the identifier system. _Slot Aggregators_ should only use a URL that is not under their control in cases where the URL is predictable and might reasonably be chosen by other _Slot Aggregators_. When this is not the case, _Slot Aggregators_ SHOULD choose a URL under their control. For example, an aggregator at `usdigitalresponse.org` might choose a URL like `https://fhir.usdigitalresponse.org/identifiers/flynns`.
+
+When the source system is a SMART Scheduling Links implementation, a _Slot Aggregator_ SHOULD use [FHIR’s `Resource.meta.source` field][resource_meta] to describe it. The value is a URI that SHOULD include the URL of the source system, and MAY add the resource `id`.
+
+For example, given the above example resource at `https://api.flynnspharmacy.org/fhir/smart-scheduling/$bulk-publish`, a _Slot Aggregator_ might publish a location like:
+
+```js
+{
+  "resourceType": "Location",
+  "id": "456",
+  "meta": {
+    "source": "https://api.flynnspharmacy.org/fhir/smart-scheduling/Location/123"
+  },
+  "identifier": [
+    {
+      "system": "https://cdc.gov/vaccines/programs/vtrcks",
+      "value": "CV1654321"
+    },
+    {
+      "system": "https://flynnspharmacy.org/",
+      "value": "123"
+    }
+  ],
+  "name": "Flynn's Pharmacy in Pittsfield, MA",
+  // additional Location fields here...
+}
+```
+
+
+### Data “Freshness”
+
+Aggregators may request or receive information from publishers at different times, and understanding how recently data about a Location, Schedule, or Slot was retrieved can help end users gauge the accuracy of items in an aggregated dataset. _Slot Aggregators_ SHOULD use the `lastSourceSync` extension on the `meta` field of any resource to indicate the last time at which the data was known to be accurate:
+
+```js
+{
+  "resourceType": "Schedule",
+  "id": "123",
+  "meta": {
+    "extension": [{
+      "url": "http://hl7.org/fhir/StructureDefinition/lastSourceSync",
+      "valueDateTime": "2021-04-19T20:35:05.000Z"
+    }]
+  }
+  // additional Schedule fields here...
+}
+```
+
+**Note:** `lastSourceSync` has been tentatively approved, but is not yet finalized as part of FHIR as of April 28, 2021. (You can keep up-to-date on the status of this extension in FHIR’s issue tracker at [FHIR-31567][].)
+
+
+### Unknown Availability, Capacity, or Slot Times
+
+Because source systems may experience errors or may not conform to the SMART Scheduling Links specification, _Slot Aggregators_ need additional tools to describe unusual situations that are not relevant to first-part _Slot Publishers_. Specifically, _Slot Aggregators_ may describe locations with:
+- Unknown slot availability (e.g. because a source system is unreachable),
+- Unknown capacity or times (e.g. slots are known to be free or busy only _at some time_ in the near future).
+
+Features and guidelines for these scenarios SHALL NOT be used by first-party _Slot Publishers_; they are described only for use by _Slot Aggregators_.
+
+
+#### Unknown Availability
+
+If there is no source of appointment data for a Schedule or a source system is unreachable, has errors, or cannot be reliably handled for some reason, a _Slot Aggregator_ should publish a single slot for the Schedule with a `status` value of `"free"` and a “Capacity” extension with a value of `0`. First-party _Slot Publishers_ SHOULD NOT publish a slot with these features; if a slot has no free capacity, the slot should have a `status` value of `"busy"`.
+
+Example usage:
+
+```json
+{
+  "resourceType": "Slot",
+  "id": "789",
+  "schedule": {
+    "reference": "Schedule/456"
+  },
+  "status": "free",
+  "start": "2021-03-10T00:00:00Z",
+  "end": "2021-03-24T00:00:00Z",
+  "extension": [{
+    "url": "http://fhir-registry.smarthealthit.org/StructureDefinition/slot-capacity",
+    "valueInteger": 0
+  }]
+}
+```
+
+
+#### Unknown Capacity or Slot Times
+
+_Slot Aggregators_ should use the **optional "Has Availability" extension** to convey that a Schedule has non-zero future availability, without conveying details about when or how much. When used on a Schedule, that Schedule MAY have no associated Slots. _Slot Publishers_ SHALL NOT use this capacity in place of publishing granular Slots; it is defined to support Slot Aggregators (i.e. systems that re-publish Slot data from other APIs).
+
+| field name | type  | description |
+|---|---|---|
+|`url`| string | fixed value of `"http://fhir-registry.smarthealthit.org/StructureDefinition/has-availability"`|
+|`valueBoolean` | boolean | `true` if this Schedule has non-zero future availability; `false` otherwise|
+
+Example usage on a Schedule:
+
+```json
+{
+  "resourceType": "Schedule",
+  "id": "456",
+  "serviceType": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/service-type",
+          "code": "57",
+          "display": "Immunization"
+        },
+        {
+          "system": "http://fhir-registry.smarthealthit.org/CodeSystem/service-type",
+          "code": "covid19-immunization",
+          "display": "COVID-19 Immunization Appointment"
+        }
+      ]
+    }
+  ],
+  "extension": [
+    {
+      "url": "http://fhir-registry.smarthealthit.org/StructureDefinition/has-availability",
+      "valueBoolean": true
+    }
+  ],
+  "actor": [
+    {
+      "reference": "Location/123"
+    }
+  ]
+}
+```
+
+
+[resource_meta]: http://hl7.org/fhir/resource.html#Meta
+[FHIR-31567]: https://jira.hl7.org/browse/FHIR-31567


### PR DESCRIPTION
After discussion with @jmandel on FHIR chat, I’m proposing a new section in the specification specifically oriented towards *Slot Aggregators*. There are a number of unusual situations aggregators encounter, but that should not apply to first-party slot publishers, and this section describes features and patterns they can use. It’s a separate section to more clearly separate it from the rest of the specification and discourage *Slot Publishers* from using these features.

I’ve tried to gather different approaches in use by folks at USDS, USDR, and VaccineSpotter or that have been discussed in chat, but this section is probably imperfect and could use some feedback.

/cc @jmandel @nickrobison-usds @GUI